### PR TITLE
[#677] Copy/paste build details from about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.14.0...develop)
 
+### Added
+
+- [DesignToolbox] Copy/paste build details from about page (Orange-OpenSource/ouds-ios#677)
+
 ### Changed
 
 - [DesignToolbox] Add title in Component and Token screens (Orange-OpenSource/ouds-ios#662)

--- a/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
+++ b/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		513AD9402C5AAADE0003253B /* OUDSTokensComponent in Frameworks */ = {isa = PBXBuildFile; productRef = 513AD93F2C5AAADE0003253B /* OUDSTokensComponent */; };
 		5149BADB2C3D6F4F000FA4BF /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 5149BADA2C3D6F4F000FA4BF /* Podfile */; };
 		514D02FC2D75F45F00622692 /* OUDSCheckboxUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514D02FB2D75F45F00622692 /* OUDSCheckboxUITests.swift */; };
+		5152DA1D2DE0BD440078B9F1 /* DesignToolboxCopyableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5152DA1C2DE0BD3B0078B9F1 /* DesignToolboxCopyableText.swift */; };
+		5152DA1E2DE0BD440078B9F1 /* DesignToolboxCopyableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5152DA1C2DE0BD3B0078B9F1 /* DesignToolboxCopyableText.swift */; };
 		5180FE6E2DBBC2FA0062E489 /* CheckboxPickerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5180FE6C2DBBC2FA0062E489 /* CheckboxPickerPage.swift */; };
 		5180FE6F2DBBC2FA0062E489 /* CheckboxPickerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5180FE6A2DBBC2FA0062E489 /* CheckboxPickerConfiguration.swift */; };
 		5180FE702DBBC2FA0062E489 /* CheckboxPickerElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5180FE6B2DBBC2FA0062E489 /* CheckboxPickerElement.swift */; };
@@ -453,6 +455,7 @@
 		513442052D75B880000B5DE4 /* CheckboxElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxElements.swift; sourceTree = "<group>"; };
 		5149BADA2C3D6F4F000FA4BF /* Podfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
 		514D02FB2D75F45F00622692 /* OUDSCheckboxUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OUDSCheckboxUITests.swift; sourceTree = "<group>"; };
+		5152DA1C2DE0BD3B0078B9F1 /* DesignToolboxCopyableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignToolboxCopyableText.swift; sourceTree = "<group>"; };
 		5180FE6A2DBBC2FA0062E489 /* CheckboxPickerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxPickerConfiguration.swift; sourceTree = "<group>"; };
 		5180FE6B2DBBC2FA0062E489 /* CheckboxPickerElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxPickerElement.swift; sourceTree = "<group>"; };
 		5180FE6C2DBBC2FA0062E489 /* CheckboxPickerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxPickerPage.swift; sourceTree = "<group>"; };
@@ -597,6 +600,7 @@
 			children = (
 				0735430F2CA15440001187EA /* Cards */,
 				0708222D2CFF617000570EC7 /* Elements */,
+				5152DA1C2DE0BD3B0078B9F1 /* DesignToolboxCopyableText.swift */,
 				07F7533A2CC785620007450D /* DesignToolboxSectionHeaderStyle.swift */,
 				07AB45862D4D08080001D237 /* DesignToolboxChoicePicker.swift */,
 				0762276B2DA93D62009C3632 /* DesignToolboxColorPicker.swift */,
@@ -1513,6 +1517,7 @@
 				072141192D02F52A00B7B9C6 /* ButtonPage.swift in Sources */,
 				0721411B2D02F52A00B7B9C6 /* ButtonElement.swift in Sources */,
 				6DB260E12CD0F0520091F72E /* NameSpace+PaddingInset.swift in Sources */,
+				5152DA1D2DE0BD440078B9F1 /* DesignToolboxCopyableText.swift in Sources */,
 				51952A752D3F9D850068B807 /* DesignToolboxTokenIllustrationBackground.swift in Sources */,
 				6DB260E22CD0F0520091F72E /* NameSpace+PaddingStack.swift in Sources */,
 				6DB260E32CD0F0520091F72E /* NameSpace+ColumnGap.swift in Sources */,
@@ -1701,6 +1706,7 @@
 				07F75A432CC654050004F1AD /* NameSpace+PaddingStack.swift in Sources */,
 				5134420E2D75B880000B5DE4 /* CheckboxElement.swift in Sources */,
 				518B26642DAE9DE1003A6ED3 /* RadioPickerPage.swift in Sources */,
+				5152DA1E2DE0BD440078B9F1 /* DesignToolboxCopyableText.swift in Sources */,
 				518B26652DAE9DE1003A6ED3 /* RadioPickerConfiguration.swift in Sources */,
 				518B26662DAE9DE1003A6ED3 /* RadioPickerElement.swift in Sources */,
 				5134420F2D75B880000B5DE4 /* CheckboxPage.swift in Sources */,

--- a/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
@@ -69,12 +69,12 @@ struct AboutPage: View {
                 }
 
                 // TODO: Only for debug purposes, should be displayed in another way
-                Text("\(Bundle.main.tokensLibraryVersion)")
-                Text("app_about_details_appVersion" <- Bundle.main.marketingVersion)
-                Text("app_about_details_buildNumber" <- Bundle.main.buildNumber)
-                Text("app_about_details_buildType" <- Bundle.main.fullBuildType)
+                DesignToolboxCopyableText("\(Bundle.main.tokensLibraryVersion)")
+                DesignToolboxCopyableText("app_about_details_appVersion" <- Bundle.main.marketingVersion)
+                DesignToolboxCopyableText("app_about_details_buildNumber" <- Bundle.main.buildNumber)
+                DesignToolboxCopyableText("app_about_details_buildType" <- Bundle.main.fullBuildType)
                 if let buildDetails = Bundle.main.buildDetails {
-                    Text("app_about_githubBuildDetails" <- buildDetails)
+                    DesignToolboxCopyableText("app_about_githubBuildDetails" <- buildDetails)
                 }
 
                 Button("app_about_appSettings_label") {

--- a/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxCopyableText.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxCopyableText.swift
@@ -1,0 +1,43 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+/// A `Text` view with a contenu menu allowing user to copy in clipboard some content.
+/// Useful for example to allow users to copy some build details or long values.
+struct DesignToolboxCopyableText: View {
+
+    let title: String
+    let copyable: String
+
+    init(_ copyableTitle: String) {
+        self.init(copyableTitle, copyableTitle)
+    }
+
+    init(_ title: String, _ copyable: String) {
+        self.title = title
+        self.copyable = copyable
+    }
+
+    var body: some View {
+        Text(title)
+            .contextMenu {
+                Button(action: {
+                    UIPasteboard.general.string = copyable
+                }, label: {
+                    Text("app_common_copy")
+                    Image(systemName: "doc.on.doc").accessibilityHidden(true)
+                })
+            }
+    }
+}

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -335,6 +335,30 @@
         }
       }
     },
+    "app_common_copy" : {
+      "comment" : "Common",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نسخ"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier"
+          }
+        }
+      }
+    },
     "app_common_copyCode_a11y" : {
       "comment" : "Common (a11y)",
       "extractionState" : "manual",


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
Orange-OpenSource/ouds-ios#677

### Description

<!-- Describe your changes in detail -->

Add cusotm view to copy text content from contextual menu

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

This evolution helps users to copy/paster easily some build details from the about page to, for example, paste in bug reports.
As build details can be long, it is quite smooth.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [ ] I checked my changes do not add new SwiftLint warnings
- [ ] I checked I am using the last version of OUDS iOS library
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- (NA)  Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [ ] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
