### PR TITLE
Add CHANGELOG hyperlink in demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/compare/0.15.0...develop)
 
+### Added
+
+- [DesignToolbox] Add in about page link to online CHANGELOG (Orange-OpenSource/ouds-ios#678)
+
 ### Changed
 
 - [Tool] Update `SwiftFormat/CLI` pod from v0.56.1 to v0.56.2

--- a/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
@@ -24,7 +24,6 @@ struct AboutPage: View {
     private let appSourcesUrl: URL
     private let bugReportUrl: URL
     private let designSystemUrl: URL
-    private let changelogURL: URL
 
     @Environment(\.layoutDirection) private var layoutDirection
 
@@ -55,17 +54,12 @@ struct AboutPage: View {
             OL.fatal("Unable to forge design system URL")
         }
 
-        guard let changelogURL = URL(string: "https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/CHANGELOG.md") else {
-            OL.fatal("Unable to forge changelog URL")
-        }
-
         privacyPolicyUrl = privacyNoticeUrl
         self.legalInformationUrl = legalInformationUrl
         self.appSettingsUrl = appSettingsUrl
         self.appSourcesUrl = appSourcesUrl
         self.bugReportUrl = bugReportUrl
         self.designSystemUrl = designSystemUrl
-        self.changelogURL = changelogURL
     }
 
     // MARK: Body
@@ -138,7 +132,9 @@ struct AboutPage: View {
             }
         }.accessibilityHint("app_about_appSettings_hint_a11y")
 
-        link(changelogURL, label: "app_about_changelog_label", hint: "app_about_changelog_hint_a11y")
+        if let changelogURL = Bundle.main.changelogURL {
+            link(changelogURL, label: "app_about_changelog_label", hint: "app_about_changelog_hint_a11y")
+        }
         link(appSourcesUrl, label: "app_about_appSources_label", hint: "app_about_appSources_hint_a11y")
         link(bugReportUrl, label: "app_about_bugReport_label", hint: "app_about_bugReport_hint_a11y")
         link(designSystemUrl, label: "app_about_designSystem_label", hint: "app_about_designSystem_hint_a11y")

--- a/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
@@ -24,6 +24,7 @@ struct AboutPage: View {
     private let appSourcesUrl: URL
     private let bugReportUrl: URL
     private let designSystemUrl: URL
+    private let changelogURL: URL
 
     @Environment(\.layoutDirection) private var layoutDirection
 
@@ -54,12 +55,17 @@ struct AboutPage: View {
             OL.fatal("Unable to forge design system URL")
         }
 
+        guard let changelogURL = URL(string: "https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/CHANGELOG.md") else {
+            OL.fatal("Unable to forge changelog URL")
+        }
+
         privacyPolicyUrl = privacyNoticeUrl
         self.legalInformationUrl = legalInformationUrl
         self.appSettingsUrl = appSettingsUrl
         self.appSourcesUrl = appSourcesUrl
         self.bugReportUrl = bugReportUrl
         self.designSystemUrl = designSystemUrl
+        self.changelogURL = changelogURL
     }
 
     // MARK: Body
@@ -132,6 +138,7 @@ struct AboutPage: View {
             }
         }.accessibilityHint("app_about_appSettings_hint_a11y")
 
+        link(changelogURL, label: "app_about_changelog_label", hint: "app_about_changelog_hint_a11y")
         link(appSourcesUrl, label: "app_about_appSources_label", hint: "app_about_appSources_hint_a11y")
         link(bugReportUrl, label: "app_about_bugReport_label", hint: "app_about_bugReport_hint_a11y")
         link(designSystemUrl, label: "app_about_designSystem_label", hint: "app_about_designSystem_hint_a11y")

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -191,6 +191,54 @@
         }
       }
     },
+    "app_about_changelog_hint_a11y" : {
+      "comment" : "About screen - Changelog hint",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انقر مرتين للانتقال إلى سجل التغيير عبر الإنترنت للمشروع"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap twice to go the the changelog of the project"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tappez deux fois pour accéder en ligne aux notes de versions"
+          }
+        }
+      }
+    },
+    "app_about_changelog_label" : {
+      "comment" : "About screen - Changelog URL",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "انظر ملاحظات الإصدار"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "See changelog"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir les notes de version"
+          }
+        }
+      }
+    },
     "app_about_designSystem_hint_a11y" : {
       "comment" : "About screen - Design system (a11y)",
       "extractionState" : "manual",

--- a/DesignToolbox/DesignToolbox/Utils/Bundle+extension.swift
+++ b/DesignToolbox/DesignToolbox/Utils/Bundle+extension.swift
@@ -34,7 +34,7 @@ extension Bundle {
     /// - "alpha" for features tests (CI/CD builds)
     /// - "beta" for develop branch (CI/CD builds nightly builds)
     /// - "stable" for main releases (CI/CD builds)
-    var buildType: String? {
+    var buildType: String {
         #if DEBUG
         "debug"
         #else
@@ -73,17 +73,25 @@ extension Bundle {
     }
 
     var fullBuildType: String {
-        let type = buildType ?? ""
         var tag = ""
         if let buildTag, !buildTag.isEmpty {
             tag = " (\(buildTag))"
         }
-        return "\(type)\(tag)"
+        return "\(buildType)\(tag)"
     }
 
     // WARNING: Do not change this value below as automatically parsed by script
     var tokensLibraryVersion: String {
         "Tokens version: 0.11.0"
+    }
+
+    /// URL to the CHANGELOG to open depending to what the CI/CD defines
+    var changelogURL: URL? {
+        #if DEBUG
+        nil
+        #else
+        URL(string: string(forInfoDictionaryKey: "OUDSSDKChangelog"))
+        #endif
     }
 
     // MARK: Private Implementation

--- a/DesignToolbox/fastlane/Fastfile
+++ b/DesignToolbox/fastlane/Fastfile
@@ -282,6 +282,7 @@ platform :ios do
     # ------------------------------------------------------------
     desc "Build the demo app in alpha mode and upload to TestFlight"
     lane :alpha do |params|
+
         issues_numbers = params[:issueNumber]
         puts "👉 Alpha (commit hash = '#{params[:commitHash]}', issue number = '#{issues_numbers}')"
 
@@ -306,6 +307,10 @@ platform :ios do
         set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSBuildType", value: "alpha")
         set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSBuildTag", value: "#{params[:commitHash][0,7]}".strip)
         set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSBuildDetails", value: "#{issues_numbers}")
+
+        sdk_branch = ouds_swift_package_git_branch
+        changelog_url = "https://github.com/Orange-OpenSource/ouds-ios/blob/#{sdk_branch}/CHANGELOG.md"
+        set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSSDKChangelog", value: "#{changelog_url}")
 
         begin
             sdk_version = ouds_swift_package_version
@@ -335,6 +340,7 @@ platform :ios do
         # Details for the GUI in the app
         set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSBuildType", value: "beta (nightly)")
         set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSBuildTag", value: "#{params[:commitHash][0,7]}".strip)
+        set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSSDKChangelog", value: "https://github.com/Orange-OpenSource/ouds-ios/blob/develop/CHANGELOG.md")
         
         begin
             sdk_version = ouds_swift_package_version
@@ -369,6 +375,7 @@ platform :ios do
 
         # Details for the GUI in the app
         set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSBuildType", value: "stable")
+        set_info_plist_value(path: "#{Dir.pwd}/../#{OUDS_PROJECT_NAME}/Info.plist", key: "OUDSSDKChangelog", value: "https://github.com/Orange-OpenSource/ouds-ios/blob/main/CHANGELOG.md")
 
         begin
             sdk_version = ouds_swift_package_version
@@ -616,6 +623,24 @@ platform :ios do
             return "#{ouds_ios_branch} (#{ouds_ios_revision[0,7]})"
         elsif ouds_ios_revision && ouds_ios_version
             return "#{ouds_ios_version} (#{ouds_ios_revision[0,7]})"
+        else
+            raise error
+        end
+    end
+
+    # Extract from Package.resolved details about the Git branch in use for the OUDS iOS Swift Package.
+    # Returns the branch if defined or raises an error.
+    # Supposes the OUDS iOS package is defined and used; if a local reference is used instead the branch won't be retrieved
+    def ouds_swift_package_git_branch()
+        puts "👉 Extract Git branch of OUDS iOS Swift package"
+
+        package_resolved_content = File.read("../#{OUDS_PACKAGE_RESOLVED_PATH}")
+        package_resolved_json_content = JSON.parse(package_resolved_content)
+        ouds_ios_obj = package_resolved_json_content['pins'].find { |pin| pin["identity"] == "ouds-ios" }
+        ouds_ios_branch = ouds_ios_obj.dig("state", "branch")
+
+        if ouds_ios_branch
+            return "#{ouds_ios_branch}"
         else
             raise error
         end


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
Orange-OpenSource/ouds-ios#678

### Description

<!-- Describe your changes in detail -->

Add link in about page making users go to changelog online in their browser

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let user get easily and fastly the changelog of the project, here the demo app, suppossing it contains changes of both the app and the lib

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] I checked I am using the last version of OUDS iOS library
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- (NA)  My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
