### PR TITLE
[#1378] Display of accessibility label in sample codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] View modifiers and methods prefixed by `ouds` are replaced by same names without such `ouds` (Orange-OpenSource/ouds-ios#1346)
 - [DesignToolbox] Move from Xcode 26.2 to Xcode 26.3 (Orange-OpenSource/ouds-ios#1375)
 
+### Fixed
+
+- [DesignToolbox] Display of accessibility label for buttons, chips and badge components sample code (Orange-OpenSource/ouds-ios#1378)
+
 ## [1.3.0](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/compare/1.2.0...1.3.0) - 2026-03-26
 
 ### Added

--- a/DesignToolbox/DesignToolbox/Pages/Components/Actions/Button/ButtonConfigurationView.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Actions/Button/ButtonConfigurationView.swift
@@ -79,7 +79,7 @@ final class ButtonConfigurationModel: ComponentConfiguration {
         case .textOnly:
             "text: \"\(text)\""
         case .iconOnly:
-            "icon: \(Image.defaultImageSample())\(flipIconPattern), accessibilityLabel: \"accessibility label\""
+            "icon: \(Image.defaultImageSample())\(flipIconPattern), accessibilityLabel: \"\(accessibilityLabelValue)\""
         case .textAndIcon:
             "text: \"\(text)\", icon: \(Image.defaultImageSample())\(flipIconPattern)"
         }
@@ -103,6 +103,10 @@ final class ButtonConfigurationModel: ComponentConfiguration {
 
     private var isFullWidthPattern: String {
         isFullWidth ? ", isFullWidth: true" : ""
+    }
+
+    private var accessibilityLabelValue: String {
+        "app_components_common_icon_a11y".localized()
     }
 
     override func updateCode() {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Controls/Chip/Filter/FilterChipConfigurationView.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Controls/Chip/Filter/FilterChipConfigurationView.swift
@@ -59,6 +59,10 @@ final class FilterChipConfigurationModel: ComponentConfiguration {
         selected ? ", selected: true" : ""
     }
 
+    private var accessibilityLabelValue: String {
+        "app_components_common_icon_a11y".localized()
+    }
+
     override func updateCode() {
         switch layout {
         case .textOnly:
@@ -70,7 +74,7 @@ final class FilterChipConfigurationModel: ComponentConfiguration {
         case .iconOnly:
             code =
                 """
-                OUDSFilterChip(icon: Image(\"ic_heart\"), accessibilityLabel: \"Some label\"\(selectedCodePattern)) {}
+                OUDSFilterChip(icon: Image(\"ic_heart\"), accessibilityLabel: \"\(accessibilityLabelValue)\"\(selectedCodePattern)) {}
                 \(disableCodePattern)
                 """
         case .textAndIcon:

--- a/DesignToolbox/DesignToolbox/Pages/Components/Controls/Chip/Suggestion/SuggestionChipConfigurationView.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Controls/Chip/Suggestion/SuggestionChipConfigurationView.swift
@@ -50,6 +50,10 @@ final class SuggestionChipConfigurationModel: ComponentConfiguration {
         !enabled ? ".disabled(true)" : ""
     }
 
+    private var accessibilityLabelValue: String {
+        "app_components_common_icon_a11y".localized()
+    }
+
     override func updateCode() {
         switch layout {
         case .textOnly:
@@ -61,7 +65,7 @@ final class SuggestionChipConfigurationModel: ComponentConfiguration {
         case .iconOnly:
             code =
                 """
-                OUDSSuggestionChip(icon: Image(\"ic_heart\"), accessibilityLabel: \"Some label\") {}
+                OUDSSuggestionChip(icon: Image(\"ic_heart\"), accessibilityLabel: \"\(accessibilityLabelValue)\") {}
                 \(disabledCode)
                 """
         case .textAndIcon:

--- a/DesignToolbox/DesignToolbox/Pages/Components/Indicators/Badge/BadgeConfigurationView.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Indicators/Badge/BadgeConfigurationView.swift
@@ -123,7 +123,7 @@ final class BadgeConfigurationModel: ComponentConfiguration {
             """
         case .icon:
             code = """
-            OUDSBadge(\(statusWithIconPattern), accessibilityLabel: \"app_components_badge_hint_a11y\", \(sizePattern))
+            OUDSBadge(\(statusWithIconPattern), accessibilityLabel: \"\(accessibilityLabelValue)\", \(sizePattern))
             \(disablePattern)
             """
         }
@@ -150,6 +150,10 @@ final class BadgeConfigurationModel: ComponentConfiguration {
 
     private var sizePattern: String {
         "size: \(badgeType == .standard ? standardSize.technicalDescription : illustrationSize.technicalDescription)"
+    }
+
+    private var accessibilityLabelValue: String {
+        "app_components_badge_hint_a11y".localized()
     }
 }
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
Orange-OpenSource/ouds-ios#1378

### Description

<!-- Describe your changes in detail -->
Do not display dumb value or wording key for accessibility label in sample code

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Have sample code tailored to components in use

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] I checked I am using the last version of OUDS iOS library
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
