### PR TITLE
[#1373] Use new tab bar init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Library] `toolbar top` and `toolbar bottom` components (Orange-OpenSource/ouds-ios#1174)
 - [Library] `text area` component (Orange-OpenSource/ouds-ios#543)
+- [DesignToolbox] `toolbar top` and `toolbar bottom` components (Orange-OpenSource/ouds-ios#1174)
+- [DesignToolbox] `text area` component (Orange-OpenSource/ouds-ios#543)
+- [DesignToolbox] `PIN code input` component (Orange-OpenSource/ouds-ios#998)
+- [Library] `borderDefault()` view modifier helper to apply a default border using default tokens from the current theme (Orange-OpenSource/ouds-ios#1379)
 - [Library] `LocalizedStringKey` and `Bundle` initializers for components using `String` for texts and accessibility labels (Orange-OpenSource/ouds-ios#1366)
 - [Library] `oudsTintColor` view modifier helper to apply tint color from a `MultipleColorSemanticToken` (Orange-OpenSource/ouds-ios#1370)
 - [Library] `verbose` flag on `OUDSLogger` to suppress debug and log messages by default (Orange-OpenSource/ouds-ios#1365)
 
 ### Changed
 
+- [DesignToolbox] `tab bar` component initialization (Orange-OpenSource/ouds-ios#1373)
+- [Library] Optimization of public API (frozen structs and enums, inlinable properties) (Orange-OpenSource/ouds-ios#1382)
 - [DesignToolbox] Use short description for components pages (Orange-OpenSource/ouds-ios#1286)
 - [Library] Update illustrations in documentation for `alert message` component (Orange-OpenSource/ouds-ios#1359)
 - [Library] View modifiers and methods prefixed by `ouds` are replaced by same names without such `ouds` (Orange-OpenSource/ouds-ios#1346)
@@ -23,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [Library] Accessibility-hint for double-tap to unselect action for `filter chip` component (Orange-OpenSource/ouds-ios##1277)
 - [DesignToolbox] Display of accessibility label for buttons, chips and badge components sample code (Orange-OpenSource/ouds-ios#1378)
 
 ## [1.3.0](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/compare/1.2.0...1.3.0) - 2026-03-26

--- a/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
+++ b/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
@@ -6052,7 +6052,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Orange-OpenSource/ouds-ios";
 			requirement = {
-				branch = "1373-for-tab-bar-component-expose-selected-value-with-a-binding";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
+++ b/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
@@ -6052,7 +6052,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Orange-OpenSource/ouds-ios";
 			requirement = {
-				branch = develop;
+				branch = "1373-for-tab-bar-component-expose-selected-value-with-a-binding";
 				kind = branch;
 			};
 		};

--- a/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/Orange-OpenSource/ouds-ios",
       "state" : {
         "branch" : "develop",
-        "revision" : "1c18a3516bd192262b1c84e4ce4ece9091fd61db"
+        "revision" : "d84a50ea212a6e6447ecae6f6363193085651592"
       }
     },
     {

--- a/DesignToolbox/DesignToolbox/MainView.swift
+++ b/DesignToolbox/DesignToolbox/MainView.swift
@@ -16,10 +16,12 @@ import SwiftUI
 
 struct MainView: View {
 
+    @State private var selectedTab: Int = 0
+
     @Environment(\.theme) private var theme
 
     var body: some View {
-        OUDSTabBar(selected: 0, count: 3) {
+        OUDSTabBar(selectedTab: $selectedTab, count: 3) {
             TokensPage()
                 .tabItem {
                     Label("app_bottomBar_tokens_label", image: "design-token")

--- a/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarConfigurationView.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarConfigurationView.swift
@@ -96,7 +96,7 @@ final class TabBarConfigurationModel: ComponentConfiguration {
 
     override func updateCode() {
         code = """
-        OUDSTabBar(selected: 0, count: \(numberOfItems)) {
+        OUDSTabBar(selectedTab: $selectedTab, count: \(numberOfItems)) {
             // Views with .tabItem and .tag calls
             \(badgePattern)
         }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarElement.swift
@@ -33,7 +33,7 @@ struct TabBarElement: DesignToolboxElement {
 struct TabBarIllustration: View {
 
     var body: some View {
-        OUDSTabBar(selected: 0, count: 3) {
+        OUDSTabBar(selectedTab: .constant(0), count: 3) {
             let wording = "app_components_common_label_label".localized()
             FakeTabItem(title: wording, imageName: "heart-empty", tag: 0)
             FakeTabItem(title: wording, imageName: "heart-empty", tag: 1)

--- a/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarPage.swift
@@ -37,6 +37,7 @@ struct TabBarPage: View {
 
 struct TabBarDemo: View {
 
+    @State private var selectedTab: Int = 0
     @ObservedObject var configurationModel: TabBarConfigurationModel
     @Environment(\.theme) private var theme
 
@@ -61,10 +62,10 @@ struct TabBarDemo: View {
     var body: some View {
         NavigationView {
             VStack(alignment: .center) {
-                OUDSTabBar(selected: 0, count: configurationModel.numberOfItems) {
+                OUDSTabBar(selectedTab: $selectedTab, count: configurationModel.numberOfItems) {
                     ForEach(configurationModel.limitedItems.indices, id: \.self) { index in
                         let item = configurationModel.limitedItems[index]
-                        TabBarItemDemo(index: index, imageName: item.imageName)
+                        TabBarItemDemo(selectedTab: selectedTab, imageName: item.imageName)
                             .tabItem {
                                 Label {
                                     Text(item.label.localized())
@@ -91,14 +92,14 @@ struct TabBarDemo: View {
 /// The view attached to the tab
 private struct TabBarItemDemo: View {
 
-    let index: Int
+    @State var selectedTab: Int
     let imageName: String
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         HStack {
-            Text("Item \(index + 1)")
+            Text("Item \(selectedTab)")
             Image.decorativeImage(named: imageName, prefixedBy: theme.name)
         }
     }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarPage.swift
@@ -62,7 +62,7 @@ struct TabBarDemo: View {
     var body: some View {
         NavigationView {
             VStack(alignment: .center) {
-                OUDSTabBar(selectedTab: $selectedTab, count: configurationModel.numberOfItems) {
+                OUDSTabBar(selectedTab: $selectedTab, count: UInt8(configurationModel.numberOfItems)) {
                     ForEach(configurationModel.limitedItems.indices, id: \.self) { index in
                         let item = configurationModel.limitedItems[index]
                         TabBarItemDemo(selectedTab: selectedTab, imageName: item.imageName)


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
Orange-OpenSource/ouds-ios#1373

### Description

<!-- Describe your changes in detail -->
Use and expose new tab bar init

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Use updated AP

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->
- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] I checked I am using the last version of OUDS iOS library
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
