### PR TITLE
[#1227] Fix vocalization on badges in tab bar demo page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [DesignToolbox] Vocalization with `Voice Over` of badges for tab bar demo (Orange-OpenSource/ouds-ios#1227) 
+- [Library] `Voice Over` announcement of displayed `alert` component (Orange-OpenSource/ouds-ios#1491)
+- [Library] Usage of `PIN code input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1631)
+- [Library] Usage of `password input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1563)
 - [Library] Usage of `text input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1562)
 - [Library] Vocalization priority for `alert message` components and usage with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1564)
 - [Library] `PIN code input` component usage with Voice Over (Orange-OpenSource/ouds-ios#1529)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [DesignToolbox] Vocalization with `Voice Over` of badges for tab bar demo (Orange-OpenSource/ouds-ios#1227) 
+- [DesignToolbox] Vocalization with `Voice Over` of badges for tab bar demo (Orange-OpenSource/ouds-ios#1227)
 - [Library] `Voice Over` announcement of displayed `alert` component (Orange-OpenSource/ouds-ios#1491)
 - [Library] Usage of `PIN code input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1631)
 - [Library] Usage of `password input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1563)

--- a/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Navigations/TabBar/TabBarPage.swift
@@ -68,8 +68,12 @@ struct TabBarDemo: View {
                         TabBarItemDemo(selectedTab: selectedTab, imageName: item.imageName)
                             .tabItem {
                                 Label {
-                                    Text(item.label.localized())
-                                        .accessibilityValue(a11yLabelForTab)
+                                    if index == 0 {
+                                        Text(item.label.localized())
+                                            .accessibilityValue(a11yLabelForTab)
+                                    } else {
+                                        Text(item.label.localized())
+                                    }
                                 } icon: {
                                     Image.decorativeImage(named: item.imageName, prefixedBy: theme.name)
                                         .renderingMode(.template)


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
Orange-OpenSource/ouds-ios#1227

### Description

<!-- Describe your changes in detail -->
Do not add accessibility label for all tabs

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Fix vocalized badge value of first tab to all tabs

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] I checked I am using the last version of OUDS iOS library
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA)Accessibility review has been done
- (NA)Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
