### PR TITLE
[#1563] Adjust title color on toolbar bar top when content color change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [DesignToolbox] Adjust title color on toolbar bar top when content color change (Orange-OpenSource/ouds-ios#1563)
 - [DesignToolbox] Status picker of progress indicators not disabled if colored surface enabled
 - [DesignToolbox] Vocalization with `Voice Over` of badges for tab bar demo (Orange-OpenSource/ouds-ios#1227)
 - [Library] `Voice Over` announcement of displayed `alert` component (Orange-OpenSource/ouds-ios#1491)

--- a/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
+++ b/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
@@ -7350,7 +7350,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Orange-OpenSource/ouds-ios";
 			requirement = {
-				branch = "1563-for-toolbar-top-adjust-title-color-on-toolbar-bar-top-when-content-color-change";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
+++ b/DesignToolbox/DesignToolbox.xcodeproj/project.pbxproj
@@ -7350,7 +7350,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Orange-OpenSource/ouds-ios";
 			requirement = {
-				branch = develop;
+				branch = "1563-for-toolbar-top-adjust-title-color-on-toolbar-bar-top-when-content-color-change";
 				kind = branch;
 			};
 		};

--- a/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Orange-OpenSource/ouds-ios",
       "state" : {
-        "branch" : "1563-for-toolbar-top-adjust-title-color-on-toolbar-bar-top-when-content-color-change",
-        "revision" : "b0166b6a272237a38d2c7b52b6b6697ebc1c5f4c"
+        "branch" : "develop",
+        "revision" : "698be894d6db5c451a20f1fc109dd01f6322a8fb"
       }
     },
     {

--- a/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Orange-OpenSource/ouds-ios",
       "state" : {
-        "branch" : "develop",
-        "revision" : "991a88984d4cf66461a90af44e12b61a6d4f3325"
+        "branch" : "1563-for-toolbar-top-adjust-title-color-on-toolbar-bar-top-when-content-color-change",
+        "revision" : "b0166b6a272237a38d2c7b52b6b6697ebc1c5f4c"
       }
     },
     {


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1563

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
